### PR TITLE
Clean up prime algorithm

### DIFF
--- a/asyncPrimeSearching.h
+++ b/asyncPrimeSearching.h
@@ -68,9 +68,9 @@ std::vector<T> partitionBorders(int numberOfPartitions, T start, T finish) {
 
 template<typename T, typename Unaryop>
 auto map(Unaryop op, std::vector<T> in){
-    std::vector<decltype(op(in[0]))> results;
-    for (auto& e : in)
-        results.push_back(op(e));
+    std::vector<decltype(op(std::move(in[0])))> results;
+    for (int i = 0; i != in.size(); i++)
+        results.push_back(op(std::move(in[i])));
     return results;
 }
 
@@ -86,7 +86,7 @@ std::vector<T> findPrimes(T start, T finish) {
     auto calculatePartition = [](T start, T end) {return std::async(primesInRange<T>, start, end); };
     return 
         accumulate( concatenate<T>, std::vector<T>{},
-            map( [](auto& x) {return x.get(); },
+            map( [](auto x) {return x.get(); },
                 applyPairwise( calculatePartition,
                     partitionBorders( threadTotal,
                         start, 


### PR DESCRIPTION
So on the previous version, `findPrimes` output depended on the number of `async`. I modified it to use a number of `async` calls appropriate for the system. Fixing the logic to then be independent was much trickier.

Also I'm no longer jumping over the numbers, the threads are given a consecutive group to process, which are then simply concatenated at the end, instead of merged.

I represented these three changes in a functional style, let me know if you're not a fan.