### PR TITLE
Hide information and optimize

### DIFF
--- a/PrimeTest.cpp
+++ b/PrimeTest.cpp
@@ -71,5 +71,8 @@ bool isLikelyPrime(int workitem) {
 }
 
 bool isLikelyPrime(mpz_class workitem) {
-	return mpz_probab_prime_p(workitem.get_mpz_t(), 25) > 1;
+	return mpz_probab_prime_p(
+        workitem.get_mpz_t(), 
+        25
+    );
 }

--- a/asyncPrimeSearching.cpp
+++ b/asyncPrimeSearching.cpp
@@ -1,0 +1,63 @@
+#include "asyncPrimeSearching.h"
+#include "primeSearchingUtilities.h"
+
+#include "PrimeTest.h"
+
+std::vector<mpz_class> partitionBorders(int numberOfPartitions, mpz_class start, mpz_class finish) {
+    std::vector<mpz_class> results;
+    mpz_class total = finish - start;
+    results.push_back(start);
+    for (int i = 0; i != numberOfPartitions; ++i) {
+        results.push_back(results[i] + (total + i) / numberOfPartitions);
+    }
+    return results;
+}
+
+struct primesInRange {
+    std::vector<mpz_class> operator()(mpz_class start, mpz_class finish) {
+        std::vector<mpz_class> primes;
+        if (start % 2 == 0) start++;
+        for (auto primeCandidate = start; primeCandidate < finish; primeCandidate = primeCandidate + 2) {
+            if (isLikelyPrime(primeCandidate)) {
+                primes.push_back(primeCandidate);
+            }
+        }
+        return primes;
+    }
+};
+
+std::vector<std::string> findPrimes(std::string start, std::string finish) {
+  
+    int threadTotal = std::thread::hardware_concurrency();
+    if (threadTotal == 0) return std::vector<std::string>{};
+    auto calculatePartition = [](mpz_class start, mpz_class end) {
+        return std::async(primesInRange{}, start, end);
+    };
+    return
+        map( [](auto x) { return x.get_str(); },
+            accumulate(concatenate<mpz_class>, std::vector<mpz_class>{},
+                map([](auto x) { return x.get(); },
+                    applyPairwise(calculatePartition,
+                        partitionBorders(threadTotal,
+                            mpz_class{ start },
+                            mpz_class{ finish }
+                        )
+                    )
+                )
+            )
+        );
+}
+
+std::string multiprecision_add(std::string first, std::string second) {
+    mpz_class x{ first };
+    mpz_class y{ second };
+    mpz_class z = x + y;
+    return z.get_str();
+}
+
+std::string multiprecision_multiply(std::string first, std::string second) {
+    mpz_class x{ first };
+    mpz_class y{ second };
+    mpz_class z = x * y;
+    return z.get_str();
+}

--- a/asyncPrimeSearching.h
+++ b/asyncPrimeSearching.h
@@ -1,100 +1,10 @@
 #pragma once
 
+#include<string>
 #include<vector>
-#include<algorithm>
-#include<numeric>
-#pragma warning( push )
-#pragma warning( disable: 4146 )
-#include "gmp.h"
-#include "gmpxx.h"
-#pragma warning( pop ) 
-#include<iostream>
-#include <memory>
-#include <cstdlib>
 
-#include<iterator>
-#include<algorithm>
-#include<future>
-#include<utility>
+std::vector<std::string> findPrimes(std::string start, std::string finish);
 
-#include "PrimeTest.h"
+std::string multiprecision_add(std::string first, std::string second);
 
-template<typename T>
-inline
-std::vector<T> concatenate(std::vector<T> first, std::vector<T> second) {
-    first.insert(std::end(first), 
-        std::make_move_iterator(std::begin(second)), 
-    	std::make_move_iterator(std::end(second)) 
-    );
-    return first;
-}
-
-//Takes elements [x1, x2, x3, x4] to [g(x1, x2), g(x2, x3), g(x3, x4)]
-template<typename T, typename G>
-inline
-auto applyPairwise(G g, std::vector<T> elements) {
-    std::vector<decltype(g(elements[0], elements[0]))> results;
-    for (int i = 0; i != (elements.size()-1); i++) {
-        results.push_back(g(elements[i], elements[i + 1]));
-    }
-    return results;
-}
-
-template<typename T>
-inline
-std::vector<T> partitionBorders(int numberOfPartitions, T start, T finish) {
-    std::vector<T> results;
-    T total = finish - start;
-    results.push_back(start);
-    for (int i = 0; i != numberOfPartitions; ++i) {
-        results.push_back(results[i] + (total + i)/numberOfPartitions);
-    }
-    return results;
-}
-
-template<typename T, typename Unaryop>
-inline
-auto map(Unaryop op, std::vector<T> in){
-    std::vector<decltype(op(std::move(in[0])))> results;
-    for (int i = 0; i != in.size(); i++)
-        results.push_back(op(std::move(in[i])));
-    return results;
-}
-
-template<typename T, typename S, typename BinaryOp>
-inline
-auto accumulate(BinaryOp op, S init, std::vector<T> factors) {
-    return std::accumulate(std::begin(factors), std::end(factors), init, op);
-}
-
-template<typename T>
-inline
-std::vector<T> primesInRange(T start, T finish) {
-    std::vector<T> primes;
-    if (start % 2 == 0) start++;
-    for (T primeCandidate = start; primeCandidate < finish; primeCandidate = primeCandidate + 2) {
-        if (isLikelyPrime(primeCandidate)) {
-            primes.push_back(primeCandidate);
-        }
-    }
-    return primes;
-}
-
-template<typename T>
-inline
-std::vector<T> findPrimes(T start, T finish) {
-    int threadTotal = std::thread::hardware_concurrency();
-    if (threadTotal == 0) return std::vector<T>{};
-    auto calculatePartition = [](T start, T end) {return std::async(primesInRange<T>, start, end); };
-    return 
-        accumulate( concatenate<T>, std::vector<T>{},
-            map( [](auto x) {return x.get(); },
-                applyPairwise( calculatePartition,
-                    partitionBorders( threadTotal,
-                        start, 
-                        finish
-                    )    
-                )
-            )
-        );
-}
+std::string multiprecision_multiply(std::string first, std::string second);

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,6 @@
 
 #include "prime.h"
 //#include "onelockthreadpool.h"
-#include "asyncPrimeSearching.h"
 #include "networkcontroller.h"
 #include "commandparser.h"
 #include "pal.h"
@@ -18,18 +17,6 @@ Primebot* Bot = nullptr;
 
 int main(int argc, char** argv)
 {
-
-    /*
-    mpz_class a = 3;
-    mpz_class b = 5000;
-    auto primes = findPrimes(a, b);
-    for (auto v : primes)
-        std::cout << v.get_str() << std::endl; //TODO: strange bug isn't linking operator<< properly.
-
-    int dummy = 0;
-    std::cin >> dummy;
-    return 0;
-    */
 
     CommandParser Parse(argc, argv);
 

--- a/prime.cpp
+++ b/prime.cpp
@@ -2,11 +2,6 @@
 #include "prime.h"
 #include "networkcontroller.h"
 #include "asyncPrimeSearching.h" 
-#pragma warning( push )
-#pragma warning( disable: 4146 )
-#pragma warning( disable: 4800 )
-#include "gmpxx.h" 
-#pragma warning( pop )
 
 
 // Yeah this is kind of ugly, Old-C style.
@@ -123,9 +118,18 @@ void Primebot::Start()
     if (Settings.PrimeSettings.UseAsync)
     {
         // Async implementation
-        mpz_class AsyncStart(Start.get());
-        mpz_class AsyncEnd(AsyncStart);
-        AsyncEnd += std::thread::hardware_concurrency() * 1000;
+        
+        char * tmp = mpz_get_str(NULL, 10, Start.get());
+        std::string AsyncStart = tmp;
+
+        // In order to free the memory we need to get the right free function:
+        void(*freefunc)(void *, size_t);
+        mp_get_memory_functions(NULL, NULL, &freefunc);
+        freefunc(tmp, std::strlen(tmp) + 1);
+        
+
+        std::string AsyncEnd(AsyncStart);
+        AsyncEnd = multiprecision_add( AsyncEnd, std::to_string(std::thread::hardware_concurrency()) + "000000");
         auto Results = findPrimes(AsyncStart, AsyncEnd);
 
         // Use network to report results
@@ -133,14 +137,14 @@ void Primebot::Start()
         {
             for (auto res : Results)
             {
-                Controller->ReportWork(*res.get_mpz_t());
+                //Controller->ReportWork(*res.get_mpz_t());
             }
         }
         else // print results to console
         {
             for (auto res : Results)
             {
-                gmp_printf("%Zd\n", res.get_mpz_t());
+                std::cout << res << std::endl << std::endl;
             }
         }
     }

--- a/prime.cpp
+++ b/prime.cpp
@@ -129,7 +129,7 @@ void Primebot::Start()
         
 
         std::string AsyncEnd(AsyncStart);
-        AsyncEnd = multiprecision_add( AsyncEnd, std::to_string(std::thread::hardware_concurrency()) + "000000");
+        AsyncEnd = multiprecision_add( AsyncEnd, std::to_string(std::thread::hardware_concurrency()) + "000");
         auto Results = findPrimes(AsyncStart, AsyncEnd);
 
         // Use network to report results

--- a/primeSearchingUtilities.h
+++ b/primeSearchingUtilities.h
@@ -1,0 +1,45 @@
+#pragma once
+#include<vector>
+#include<algorithm>
+#include<numeric>
+
+#include<iostream>
+#include <memory>
+#include <cstdlib>
+
+#include<iterator>
+#include<algorithm>
+#include<future>
+#include<utility>
+
+template<typename T>
+std::vector<T> concatenate(std::vector<T> first, std::vector<T> second) {
+    first.insert(std::end(first),
+        std::make_move_iterator(std::begin(second)),
+        std::make_move_iterator(std::end(second))
+    );
+    return first;
+}
+
+template<typename T, typename Unaryop>
+auto map(Unaryop op, std::vector<T> in) {
+    std::vector<decltype(op(std::move(in[0])))> results;
+    for (int i = 0; i != in.size(); i++)
+        results.push_back(op(std::move(in[i])));
+    return results;
+}
+
+template<typename T, typename S, typename BinaryOp>
+auto accumulate(BinaryOp op, S init, std::vector<T> factors) {
+    return std::accumulate(std::begin(factors), std::end(factors), init, op);
+}
+
+//Takes elements [x1, x2, x3, x4] to [g(x1, x2), g(x2, x3), g(x3, x4)]
+template<typename T, typename G>
+auto applyPairwise(G g, std::vector<T> elements) {
+    std::vector<decltype(g(elements[0], elements[0]))> results;
+    for (int i = 0; i != (elements.size() - 1); i++) {
+        results.push_back(g(elements[i], elements[i + 1]));
+    }
+    return results;
+}


### PR DESCRIPTION
I was disappointed with how invasive some of these headers could be. I exposed an interface to find primes that doesn't use `mpz_class`, it's less type safe but now windows headers don't need to interact with the `gmpxx.h` used in my implementation.

I also specialized the implementation of `findPrimes`, and `primesInRange`. And made `primesInRange` into a functor to trigger inlining. The tests on my end seem to imply it worked. I removed the other inlining flags on the algorithms, because they didn't seem to have an effect.

Finally, In `isLikelyPrime` I changed `mpz_probab_prime_p(workitem.get_mpz_t(), 25) > 1` to `mpz_probab_prime_p(workitem.get_mpz_t(), 25)`. This returns true for all numbers that are likely prime, instead of all numbers that are definitely prime. Now it's not "arbitrarily" dropping primes...